### PR TITLE
[enh] Add DuPre git lesson

### DIFF
--- a/tu-git-dupre/01-local.md
+++ b/tu-git-dupre/01-local.md
@@ -1,0 +1,361 @@
+---
+title: "Tracking changes with a local repository"
+teaching: 35
+exercises: 0
+questions:
+- "How do I get started with Git?"
+objectives:
+- "Know how to set up a new Git repository."
+- "Understand how to start tracking files."
+- "Be able to commit changes to your repository."
+keypoints:
+- "`git init` initializes a new repository"
+- "`git status` shows the status of a repository"
+- "Files can be stored in a project’s `working directory` (which users see),
+  the `staging area` (where the next commit is being built up) and the
+  `local repository` (where commits are permanently recorded)"
+- "`git add` puts files in the staging area"
+- "`git commit` saves the staged content as a new commit in the local repository"
+- "Always write a log message when committing changes"
+---
+
+Version control is centered round the notion of a *repository* which holds your
+directories and files. We'll start by looking at a local repository. The local
+repository is set up in a directory in your local file system (local machine).
+For this we will use the command line interface.
+
+> ## Why are we using the command line?
+
+> There are lots of graphical user interfaces (GUIs) for using Git: both stand-alone
+> and integrated into text editors (e.g. VSCode).
+> We are deliberately not using a GUI for this course because:
+>
+> * you will have a better understanding of how the git commands work
+> * you will be able to use Git on any computer
+> (e.g. remotely accessing HPC systems, which generally only have Linux command line access)
+> * you will be able to use any GUI, rather than just the one you have learned
+{: .callout}
+
+## Setting up Git
+
+If you're using the course JupyterHub, git should already be installed.
+If you need to install git locally, instructions are under [setup]({{ page.root }}/setup).
+
+## Tell Git who we are
+
+Git records information not only about the changes to files,
+but also about _who_ made those changes.
+In collborating, this information is often critical
+(e.g., you probably want to know who rewrote your 'Conclusions' section!).
+So, we need to tell Git about who we are:
+
+~~~
+$ git config --global user.name "Your Name" 			# Put quotation marks around your name
+$ git config --global user.email yourname@yourplace.org
+~~~
+{: .language-bash}
+
+Note that you need to enclose your name in quotation marks!
+
+## Set a default editor
+
+When working with Git we will often need to provide some short but useful information.
+In order to enter this information, we need an editor.
+We'll now tell Git which editor we want to be the default
+(i.e. the one that Git will bring by default whenever it wants us to provide some information).
+
+You can choose any editor available on your system.
+For the purpose of this session we'll assume you're on the course JupyterHub and use *vim*:
+
+~~~
+$ git config --global core.editor vim
+~~~
+{: .language-bash}
+
+To set up alternative editors, follow the same notation e.g.
+`git config --global core.editor notepad`, `git config --global core.editor vi`,
+`git config --global core.editor xemacs`.
+
+Mac users can use *TextEdit*: `git config --global core.editor 'open -W -n'`.
+
+## Git's global configuration
+
+We can now preview (and edit, if necessary) Git's global configuration (such as
+our name and the default editor which we just set up). If we look in our home
+directory, we'll see a `.gitconfig` file,
+
+~~~
+$ cat ~/.gitconfig
+    [user] name = Your Name email = yourname@yourplace.org
+    [core] editor = vim
+~~~
+{: .language-bash}
+
+**These global configuration settings will apply to any new Git repository
+you create on the course JupyterHub.**
+If you are executing this tutorial locally, these settings would similarly persist over time;
+i.e. the `--global` commands above are only required once per computer.
+
+---
+
+## Create a new repository with Git
+
+We will be working with a simple example in this tutorial. It will be a paper
+that we will first start writing as a single author and then work on it further
+with one of our colleagues.
+
+ First, let's create a directory within your home directory:
+
+```
+$ cd								# Switch to your home directory.
+$ pwd								# Print working directory (output should be /home/jovyan)
+$ mkdir git-papers
+$ cd git-papers
+```
+{: .language-bash}
+
+Now, we need to set up this directory up to be a Git repository (or "initiate
+the repository"):
+
+~~~
+$ git init
+~~~
+{: .language-bash}
+~~~
+Initialized empty Git repository in /home/user/git-papers/.git/
+~~~
+{: .output}
+
+The directory "git-papers" is now our working directory.
+
+ If we look in this directory, we'll find a `.git` directory:
+
+~~~
+$ ls .git
+~~~
+{: .language-bash}
+~~~
+branches  config  description  HEAD  hooks  info  objects refs
+~~~
+{: .output}
+The `.git` directory contains Git's configuration files. Be careful not to
+accidentally delete this directory!
+
+## Tracking files with a git repository
+
+Now, we'll create a file. Let's say we're going to write a journal paper, so
+we will start by adding the author names and a title, then save the file.
+
+~~~
+$ vim journal.md
+# Add author names and paper title
+~~~
+{: .language-bash}
+
+> ## Accessing files from the command line
+
+> In this lesson we create and modify text files using a command line interface
+> (e.g. terminal, Git Bash etc), mainly for convenience.
+> JupyterHub also contains a native text editor that we can use to edit these files.
+> That is because these are normal files which are also accessible from the file browser on any operating system (e.g. Windows explorer),
+> and by other programs.
+{: .callout}
+
+`git status` allows us to find out about the current status
+of files in the repository. So we can run,
+
+~~~
+$ git status
+~~~
+{: .language-bash}
+~~~
+On branch master
+
+Initial commit
+
+Untracked files:
+(use "git add <file>..." to include in what will be committed)
+
+journal.md
+
+nothing added to commit but untracked files present (use "git add" to track)
+~~~
+{: .output}
+
+Information about what Git knows about the directory is displayed. We are on
+the `master` branch, which is the default branch in a Git repository
+(one way to think of branches is like parallel versions of the project.
+Don't worry -- we'll talk more about branches later).
+
+For now, the important bit of information is that our file is listed as
+**Untracked** which means it is in our working directory but Git is not
+tracking it - that is, any changes made to this file will not be recorded by
+Git.
+
+## Add files to a Git repository
+
+To tell Git about the file, we will use the `git add` command:
+
+~~~
+$ git add journal.md
+$ git status
+~~~
+{: .language-bash}
+~~~
+On branch master
+
+Initial commit
+
+Changes to be committed:
+(use "git rm --cached <file>..." to unstage)
+
+      	new file:   journal.md
+~~~
+{: .output}
+
+Now our file is listed underneath where it says **Changes to be committed**.
+
+`git add` is used for two purposes. Firstly, to tell Git that a given file
+should be tracked. Secondly, to put the file into the Git **staging area**
+which is also known as the *index* or the *cache*.
+
+The staging area can be viewed as a "loading dock", a place to hold files we have
+added, or changed, until we are ready to tell Git to record those changes in the
+repository.
+
+![The staging area](../fig/git-staging-area.svg)
+
+## Commit changes
+
+In order to tell Git to record our change, our new file, into the repository,
+we need to  **commit** it:
+
+~~~
+$ git commit
+# Type a commit message: "Add title and authors"
+# Save the commit message and close your text editor (vim, notepad etc.)
+~~~
+{: .language-bash}
+
+Our default editor will now pop up. Why? Well, Git can automatically figure out
+that directories and files are committed, and by whom (thanks to the information
+we provided before) and even, what changes were made, but it cannot figure out
+why. So we need to provide this in a commit message.
+
+If we save our commit message **and exit the editor**, Git will now commit our file.
+
+~~~
+[master (root-commit) 21cfbde]
+1 file changed, 2 insertions(+) Add title and authors
+create mode 100644 journal.md
+~~~
+{: .output}
+
+This output shows the number of files changed and the number of lines inserted
+or deleted across all those files. Here, we have changed (by adding) 1 file and
+inserted 2 lines.
+
+Now, if we look at its status,
+
+~~~
+$ git status
+~~~
+{: .language-bash}
+~~~
+On branch master
+nothing to commit, working directory clean
+~~~
+{: .output}
+
+our file is now in the repository.
+The output from the `git status` command means that we have a clean directory
+i.e. no tracked but modified files.
+
+Now we will work a bit further on our *journal.md* file by writing the introduction
+section.
+
+```
+$ nano journal.md
+# Write introduction section
+```
+{: .language-bash}
+If we now run,
+
+~~~
+$ git status
+~~~
+{: .language-bash}
+
+we see changes not staged for commit section and our file is marked as
+modified:
+
+~~~
+On branch master
+Changes not staged for commit:
+(use "git add <file>..." to update what will be committed)
+(use "git checkout -- <file>..." to discard changes in working directory)
+
+     modified:   journal.md
+
+no changes added to commit (use "git add" and/or "git commit -a")
+~~~
+{: .output}
+
+This means that a file Git knows about has been modified by us but
+has not yet been committed. So we can add it to the staging area and then
+commit the changes:
+
+~~~
+$ git add journal.md
+$ git commit							# "Write introduction"
+~~~
+{: .language-bash}
+Note that in this case we used `git add` to put journal.md to the staging
+area. Git already knows this file should be tracked but doesn't know if we want
+to commit the changes we made to the file  in the repository and hence we have
+to add the file to the staging area.
+
+It can sometimes be quicker to provide our commit messages at the command-line
+by doing `git commit -m "Write introduction section"`.
+
+Let's add a directory *common* and a file *references.txt* for references we may
+want to reuse:
+
+~~~
+$ mkdir common
+$ vim common/references.txt					# Add a reference
+~~~
+{: .language-bash}
+
+We will also add a citation in our introduction section (in journal.md).
+
+~~~
+$ vim journal.md 						# Use reference in introduction
+~~~
+{: .language-bash}
+
+Now we need to record our work in the repository so we need to make a commit.
+First we tell Git to track the references.
+We can actually tell Git to track everything in the given sub-directory:
+
+~~~
+$ git add common						# Track everything currently in the 'common' directory
+$ git status							# Verify that common/references.txt is now tracked
+~~~
+{: .language-bash}
+
+All files that are in *common* are now tracked.  We would also have to add
+journal.md in the staging area. But there is a shortcut. We can use
+`commit -a`. This option means "commit all files that are tracked and
+that have been modified".
+
+~~~
+$ git commit -am "Reference J Bloggs and add references file" 	# Add and commit all tracked files
+~~~
+{: .language-bash}
+and Git will add, then commit, both the directory and the file.
+
+In order to add all tracked files to the staging area, use `git commit -a`
+(which may be very useful if you edit e.g. 10 files and now you want to commit all of them).
+
+![The Git commit workflow](../fig/git-committing.svg)

--- a/tu-git-dupre/02-history.md
+++ b/tu-git-dupre/02-history.md
@@ -1,0 +1,171 @@
+---
+title: "Looking at history and differences"
+teaching: 20
+exercises: 0
+questions:
+- "How does Git store information?"
+objectives:
+- "Be able to view history of changes to a repository"
+- "Be able to view differences between commits"
+keypoints:
+- "`git log` shows the commit history"
+- "`git diff` displays differences between commits"
+- "`git checkout` recovers old versions of files"
+---
+
+
+### Looking at differences
+
+We forgot to reference a second paper in the introduction section.
+Correct it, save the file but do not commit it yet.
+We can review the changes that we made using:
+
+~~~
+$ vim journal.md		# Add second reference to introduction
+$ git diff journal.md		# View changes to file
+~~~
+{: .language-bash}
+
+This shows the difference between the latest copy in the repository and the
+unstaged changes we have made.
+
+* `-` means a line was deleted.
+* `+` means a line was added.
+* Note that a line that has been edited is shown as a removal of the old line and an
+addition of the updated line.
+
+Looking at differences between commits is very useful!
+Note that the `git diff` command itself has a number of [useful
+options](http://git-scm.com/docs/git-diff.html).
+
+Now commit the change we made by adding the second reference:
+```
+$ git add journal.md
+$ git commit			# "Reference second paper in introduction"
+```
+{: .language-bash}
+
+### Looking at our history
+
+To see the history of changes that we made to our repository (the most recent
+changes will be displayed at the top):
+
+~~~
+$ git log
+~~~
+{: .language-bash}
+
+```
+commit 4dd7f5c948fdc11814041927e2c419283f5fe84c
+Author: Your Name <your.name@yourplace.org>
+Date:   Mon Jun 26 10:21:48 2017 +0100
+
+    Write introduction
+
+commit c38d2243df9ad41eec57678841d462af93a2d4a5
+Author: Your Name <your.name@yourplace.org>
+Date:   Mon Jun 26 10:14:30 2017 +0100
+
+    Add author and title
+```
+{: .output}
+
+The output shows (on separate lines):
+- the commit identifier (also called revision number) which
+uniquely identifies the changes made in this commit
+- author
+- date
+- your commit message
+
+Git automatically assigns an identifier (e.g. 4dd7f5) to each commit
+made to the repository
+--- we refer to this as *COMMITID* in the code blocks below.
+In order to see the changes made between any earlier commit and our
+current version, we can use  `git diff` followed by the commit identifier of the
+earlier commit:
+
+~~~
+$ git diff COMMITID		# View differences between current version and COMMITID
+~~~
+{: .language-bash}
+
+And, to see changes between two commits:
+
+~~~
+$ git diff OLDER_COMMITID NEWER_COMMITID
+~~~
+{: .language-bash}
+
+Using our commit identifiers we can set our working directory to contain the
+state of the repository as it was at any commit. So, let's go back to the very
+first commit we made,
+
+~~~
+$ git log
+$ git checkout INITIAL_COMMITID
+~~~
+{: .language-bash}
+
+We will get something like this:
+
+~~~
+Note: checking out '21cfbdec'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b new_branch_name
+
+HEAD is now at 21cfbde... Add title and authors
+~~~
+{: .output}
+
+If we look at `journal.md` we'll see it's our very first version. And if we
+look at our directory,
+
+~~~
+$ ls
+~~~
+{: .language-bash}
+~~~
+journal.md
+~~~
+{: .output}
+
+then we see that our `common` directory is gone. But, rest easy, while it's
+gone from our working directory, it's still in our repository! We can jump back
+to the latest commit by doing:
+
+~~~
+$ git checkout master
+~~~
+{: .language-bash}
+
+And `common` will be there once more,
+
+~~~
+$ ls
+~~~
+{: .language-bash}
+~~~
+common journal.md
+~~~
+{: .output}
+So we can get any version of our files from any point in time. In other words,
+we can set up our working directory back to any stage it was when we made
+a commit!
+
+If we want to make a commit now, we should create a new branch to retain these commits.
+If we created a new commit without first creating a new branch, these commits would not overwrite any of our existing work, but they would not belong to any branch.
+In order to save this work, we would need to checkout a new branch.
+To discard any changes we make, we can just checkout master again.
+
+> ## Where to create a Git repository?
+> Avoid creating a Git repository within another Git repository.
+> Nesting repositories in this way causes the 'outer' repository to
+> track the contents of the 'inner' repository - things will get confusing!
+{: .callout}

--- a/tu-git-dupre/03-branching.md
+++ b/tu-git-dupre/03-branching.md
@@ -1,0 +1,106 @@
+---
+title: "Branching"
+teaching: 10
+exercises: 10
+questions:
+- "What is a branch?"
+- "How can I merge changes from another branch?"
+objectives:
+- "Know what branches are and why you would use them"
+- "Understand how to merge branches"
+- "Understand how to resolve conflicts during a merge"
+keypoints:
+- "`git branch` creates a new branch"
+- "Use feature branches for new ideas and fixes, before merging into `master`"
+- merging does not delete any branches
+---
+
+### What is a branch?
+
+You might have noticed the term *branch* in status messages:
+
+~~~
+$ git status
+~~~
+{: .language-bash}
+~~~
+On branch master
+nothing to commit (working directory clean)
+~~~
+{: .output}
+
+and when we wanted to get back to our most recent version of the repository, we
+used `git checkout master`.
+
+Not only can our repository store the changes made to files and directories, it
+can store multiple sets of these, which we can use and edit and update in
+parallel. Each of these sets, or parallel instances, is termed a `branch` and
+`master` is Git's default branch.
+
+A new branch can be created from any commit. Branches can also be *merged*
+together.
+
+### Why are branches useful?
+Suppose we've developed some software and now we want to
+try out some new ideas but we're not sure yet whether we'll keep them. We
+can then create a branch 'feature1' and keep our `master` branch clean. When
+we're done developing the feature and we are sure that we want to include it
+in our program, we can merge the feature branch with the `master` branch.
+This keeps all the work-in-progress separate from the `master` branch, which
+contains tested, working code.
+
+When we merge our feature branch with master git creates a new commit which
+contains merged files from master and feature1. After the merge we can continue
+developing. **The merged branch is not deleted.** We can continue developing (and
+making commits) in feature1 as well.
+
+
+### Branching in practice
+
+One of our colleagues wants to contribute to the paper but is not quite sure
+if it will actually make a publication. So it will be safer to create a branch
+and carry on working on this "experimental" version of the paper in a branch
+rather than in the master.
+
+~~~
+$ git checkout -b paperWJohn
+~~~
+{: .language-bash}
+~~~
+Switched to a new branch 'paperWJohn'
+~~~
+{: .output}
+
+We're going to change the title of the paper and update the author list (adding John Smith).
+However, before we get started it's a good practice to check that we're working
+on the right branch.
+
+~~~
+$ git branch			# Double check which branch we are working on
+~~~
+{: .language-bash}
+~~~
+  master
+* paperWJohn
+~~~
+{: .output}
+
+The * indicates which branch we're currently in. Now let's make the changes to the paper.
+
+~~~
+$ vim journal.md		# Change title and add co-author
+$ git add journal.md
+$ git commit			# "Modify title and add John as co-author"
+~~~
+{: .language-bash}
+
+If we now want to work in our `master` branch. We can switch back by using:
+
+~~~
+$ git checkout master
+~~~
+{: .language-bash}
+~~~
+Switched to branch 'master'
+~~~
+{: .output}

--- a/tu-git-dupre/04-remote.md
+++ b/tu-git-dupre/04-remote.md
@@ -1,0 +1,221 @@
+---
+title: "Getting started with GitHub"
+teaching: 25
+exercises: 0
+questions:
+- "What is a remote repository?"
+- "How can I use GitHub to work from multiple locations?"
+objectives:
+- "Understand how to set up remote repository"
+- "Understand how to push local changes to a remote repository"
+- "Understand how to clone a remote repository"
+keypoints:
+- "Git is the version control system: GitHub is a remote repositories provider."
+- "`git clone` to make a local copy of a remote repository"
+- "`git push` to send local changes to remote repository"
+---
+
+We're going to set up a remote repository that we can use from multiple
+locations. The remote repository can also be shared with colleagues, if we want
+to.
+
+### GitHub
+
+[GitHub](http://GitHub.com) is a company which provides remote repositories for
+Git and a range of functionalities supporting their use. GitHub allows users to
+set up  their private and public source code Git repositories. It provides
+tools for browsing, collaborating on and documenting code. GitHub, like other
+services such as [GitLab](https://about.gitlab.com/) and
+[Bitbucket](https://bitbucket.org),  supports a wealth of resources to support
+projects including:
+
+* Browsing code from within a web browser, with syntax highlighting
+* Software release management
+* Issue and bug tracking
+* Project management tools
+
+### GitHub for research
+
+GitHub **isn't** the only remote repositories provider.
+It is very popular, however, particularly within the open source communities.
+
+Also, GitHub has [functionality which is particularly useful
+for researchers](https://github.com/blog/1840-improving-github-for-sciences)
+such as making code citable!
+
+---
+
+### Get an account
+
+Let's get back to our tutorial. We'll first need a GitHub account.
+
+[Sign up](https://GitHub.com) or [sign in](https://GitHub.com) if you already have an account.
+
+### Create a new repository
+
+Now, we can create a repository on GitHub,
+
+* Log in to [GitHub](https://GitHub.com/)
+* Click on the **Create** icon on the top right
+* Enter Repository name: "git-papers"
+* For the purpose of this exercise we'll create a public repository
+* Since we'll be importing a local repository, make sure that **Initialize this repository with a README** is **unselected**
+* Click **Create Repository**
+
+You'll get a page with new information about your repository. We already have
+our local repository and we will be *pushing* it to GitHub,
+so we can do the following:
+
+```
+$ git remote add origin https://github.com/<USERNAME>/git-papers.git
+```
+{: .language-bash}
+
+This line sets up an alias `origin`,
+to correspond to the URL of our new repository on GitHub.
+
+### Push locally tracked files to a remote repository
+
+Now we can execute the following:
+
+```
+$ git push -u origin master
+```
+{: .language-bash}
+```
+Counting objects: 32, done.
+Delta compression using up to 8 threads.
+Compressing objects: 100% (28/28), done.
+Writing objects: 100% (32/32), 3.29 KiB | 0 bytes/s, done.
+Total 32 (delta 7), reused 0 (delta 0)
+To https://github.com/emdupre/git-papers.git
+ * [new branch]      master -> master
+Branch master set up to track remote branch master from origin.
+```
+{: .output}
+
+This **pushes** our `master` branch to the remote repository, (named via the alias `origin`) and creates a new `master` branch in the remote repository.
+
+Now, on GitHub, we should see our code,
+and if we click the `Commits` tab we should see our complete history of commits.
+
+Our local repository is now available on GitHub.
+This means that anywhere we can access GitHub,
+we can access our repository!
+
+### Push other local branches to a remote repository
+
+Let's push each of our local branches into our remote repository:
+
+```
+$ git push origin branch_name
+```
+{: .language-bash}
+
+The branch should now be created in our GitHub repository.
+
+To list all branches (local and remote):
+
+```
+$ git branch -a
+```
+{: .language-bash}
+
+> ## Deleting branches (for information only)
+> **Don't do this now.** This is just for information.
+> To delete branches, use the following syntax:
+>
+> ```
+> $ git branch -d <branch_name>			# For local branches
+> $ git push origin --delete <branch_name>	# For remote branches
+> ```
+> {: .language-bash}
+{: .callout}
+
+### Cloning a remote repository
+
+Now, let's do something drastic!
+But before that step,
+**make sure that you pushed all your local branches into the remote repository!**
+
+```
+$ cd ..
+$ rm -rf git-papers
+```
+{: .language-bash}
+
+Gulp! We've just wiped our local repository!
+But, because we've pushed to GitHub, we have still have a copy!
+We can just copy the repository down using `git clone`:
+
+```
+$ git clone https://github.com/<USERNAME>/git-papers.git
+```
+{: .language-bash}
+```
+Cloning into 'git-papers'...
+remote: Counting objects: 32, done.
+remote: Compressing objects: 100% (21/21), done.
+remote: Total 32 (delta 7), reused 32 (delta 7), pack-reused 0
+Unpacking objects: 100% (32/32), done.
+Checking connectivity... done.
+```
+{: .output}
+
+Cloning creates an exact copy of the repository. By default it creates
+a directory with the same name as the name of the repository.
+
+Now, if we change into *git-papers* we can see that we have our repository,
+
+```
+$ cd git-papers
+$ git log
+```
+{: .language-bash}
+and we can see our Git configuration files too:
+
+```
+$ ls -A
+```
+{: .language-bash}
+
+In order to see the other branches locally, we can check them out as before:
+
+```
+$ git branch -r					# Show remote branches
+$ git checkout paperWJohn			# Check out the paperWJohn branch
+```
+{: .language-bash}
+
+### Push changes to a remote repository
+
+We can use our cloned repository just as if it were the original, local repository !
+So, let's make some changes to our files and commit these.
+
+```
+$ git checkout master				# We'll continue working on the master branch
+$ vim journal.md				# Add results section
+$ git add journal.md				# Stage changes
+$ git commit
+```
+{: .language-bash}
+
+Having done that, how do we send our changes back to the remote repository?
+We can do this by *pushing* our changes:
+
+```
+$ git push origin master
+```
+{: .language-bash}
+
+If we now check our GitHub page we should be able to see our new changes under
+the *Commit* tab.
+
+To see all configured remotes for this repository (we can have multiple!),
+type:
+
+```
+$ git remote -v
+```
+{: .language-bash}
+{: .language-bash}

--- a/tu-git-dupre/05-remote-collaboration.md
+++ b/tu-git-dupre/05-remote-collaboration.md
@@ -1,0 +1,281 @@
+---
+title: "Collaborating with a remote repository"
+teaching: 25
+exercises: 0
+questions:
+- "How do I update my local repository with changes from the remote?"
+- "How can I collaborate using Git?"
+objectives:
+- "Understand how to pull changes from remote repository"
+- "Understand how to resolve merge conflicts"
+keypoints:
+- "`git pull` to integrate remote changes into local copy of repository"
+---
+
+
+### Pulling changes from a remote repository
+
+Now when we have a remote repository, we can share it and collaborate with
+others (and we can also work from multiple locations: for example from a laptop
+and a desktop in the lab). But how do we get the latest changes? One way is
+simply to clone the repository every time-- but this is inefficient, especially
+if our repository is very large! So, Git allows us to get the latest changes
+down from a repository.
+
+We'll first do a "dry run" of pulling changes from a remote repository and
+then we'll work in pairs for some real-life practice.
+
+First, let us leave our current local repository,
+
+```
+$ cd ..
+$ ls
+```
+{: .language-bash}
+
+```
+$ git-papers
+```
+{: .output}
+
+And let us clone our repository again, but this time specify the local
+directory name,
+
+```
+$ git clone https://github.com/<USERNAME>/git-papers.git nha-papers
+Cloning into 'nha-papers'...
+```
+{: .language-bash}
+
+So we now have two clones of our repository,
+
+```
+$ ls
+```
+{: .language-bash}
+
+```
+$ git-papers nha-papers
+```
+{: .output}
+
+Let's pretend these clones are on two separate machines!
+So then we have 3 versions of our repository:
+our two local versions on  separate machines (we're still pretending!)
+and one on GitHub.
+We can edit one of our clones, add a figures section,
+commit the file and push these changes to GitHub:
+
+```
+$ cd git-papers 			# Switch to the 'git-papers' directory
+$ vim journal.md		# Add figures section
+$ git add journal.md
+$ git commit -m "Add figures"
+$ git push
+```
+{: .language-bash}
+
+Now let's change directory to our other clone and `fetch` the commits from our remote repository:
+
+```
+$ cd ../nha-papers		# Switch to the other directory
+$ git fetch
+```
+{: .language-bash}
+
+We can now see what the differences are by doing,
+
+```
+$ git diff origin/master
+```
+{: .language-bash}
+
+which compares our `master` branch with the `origin/master` branch.
+`origin/master` is the name of the `master` branch in `origin`
+(which is the alias for our cloned repository); that is, the one on GitHub.
+
+We can then `merge` these changes into our current repository,
+but given the history hasn't diverged, we don't need a merge commit.
+Instead we get a *fast-forward* merge.
+
+```
+$ git merge origin/master
+```
+{: .language-bash}
+
+```
+Updating 0cc2a2d..7c239c3
+Fast-forward
+ journal.md | 4 ++++
+ 1 file changed, 4 insertions(+)
+```
+{: .output}
+
+We can inspect the file to confirm that we have our changes.
+
+```
+$ cat journal.md
+```
+{: .language-bash}
+
+Note that, as a short-hand,
+we can do a `git pull` which does a `git fetch` followed by a `git merge`.
+Next we will update our repo using `git pull`,
+but this time starting with changes in the *nha-papers* folder
+(you should already be in the *nha-papers* folder!).
+Let's write the conclusions:
+
+```
+$ vim journal.md		# Write Conclusions
+$ git add journal.md
+$ git commit -m "Write Conclusions" journal.md
+$ git push origin master
+$ cd ../git-papers			# Switch back to the git-papers directory
+$ git pull origin master	# Get changes from remote repository
+```
+{: .language-bash}
+
+This is the same scenario as before, so we get another fast-forward merge!
+
+We can check that we have our changes:
+
+```
+$ cat journal.md
+$ git log
+```
+{: .language-bash}
+
+> ## `Fetch` vs `pull`
+> If `git pull` is a shortcut for `git fetch` followed by `git merge` then, why would
+> you ever want to do these steps separately?
+>
+> Well, depending on what the commits on the remote branch contain,
+> you might want to e.g., abandon your local commits before merging.
+>
+> Fetching first lets you inspect the changes
+> before deciding what you want to do with them.
+{: .callout}
+
+### Conflicts and how to resolve them
+
+Let's continue to pretend that our two local, cloned, repositories are hosted
+on two different machines.
+You should currently be in the original *git-papers* folder.
+Let's add an affiliation for each author,
+and then push these changes to our remote repository:
+
+```
+$ nano journal.md		# Add author affiliations
+$ git add journal.md
+$ git commit -m "Add author affiliations"
+$ git push origin master
+```
+{: .language-bash}
+
+Now let us suppose, at a later date,
+we use our other repository (the `nha-papers` clone) on another machine,
+and we want to change the order of the authors.
+
+The remote branch `origin/master` is now ahead of our local `master` branch on the other machine,
+because we haven't yet updated our local branch using `git pull`.
+
+```
+$ cd ../nha-papers		# Switch directory to other copy of our repository
+$ vim journal.md		# Change order of the authors
+$ git add journal.md
+$ git commit -m "Change the first author" journal.md
+$ git push origin master
+```
+{: .language-bash}
+```
+To https://github.com/<USERNAME>/git-papers.git
+ ! [rejected]        master -> master (fetch first)
+error: failed to push some refs to 'https://github.com/<USERNAME>/git-papers.git'
+hint: Updates were rejected because the remote contains work that you do
+hint: not have locally. This is usually caused by another repository pushing
+hint: to the same ref. You may want to first integrate the remote changes
+hint: (e.g., 'git pull ...') before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+```
+{: .output}
+
+Our push fails, as we've not yet pulled down our changes from our remote
+repository!
+But don't panic.
+Before pushing we should always pull, so let's do that...
+
+```
+$ git pull origin master
+```
+{: .language-bash}
+
+and we get:
+
+```
+Auto-merging journal.md
+CONFLICT (content): Merge conflict in journal.md
+Automatic merge failed; fix conflicts and then commit the result.
+```
+{: .output}
+
+As we saw earlier, with the fetch and merge,
+`git pull` pulls down changes from the
+repository and tries to merge them.
+It does this on a file-by-file basis,
+merging files line by line.
+We get a **conflict** if a file has changes that
+affect the same lines and those changes can't be seamlessly merged.
+We had this situation before in the *branching* episode,
+ when we merged a *feature* branch into *master*.
+If we look at the status:
+
+```
+$ git status
+```
+{: .language-bash}
+
+we can see that our file is listed as *Unmerged* and if we look at
+*journal.md*, we see something like:
+
+```
+<<<<<<< HEAD
+Author
+E DuPre, J Smith
+=======
+author
+J Smith, E DuPre
+>>>>>>> 1b55fe7f23a6411f99bf573bfb287937ecb647fc
+```
+
+The mark-up shows us the parts of the file causing the conflict and the
+versions they come from. We now need to manually edit the file to *resolve* the
+conflict. Just like we did when we had to deal with the conflict when we were
+merging the branches.
+
+We edit the file. Then commit our changes. Now, if we *push* ...
+
+```
+$ vim journal.md		# Edit file to resolve merge conflict
+$ git add journal.md		# Stage the file
+$ git commit			# Commit to mark the conflict as resolved
+$ git push origin master
+```
+{: .language-bash}
+
+... all goes well!
+If we now go to GitHub and click on the "Overview" tab,
+we can see where our repository diverged and came together again.
+
+This is where version control proves itself better than DropBox or GoogleDrive!
+This allows us to merge text files line-by-line and highlight the conflicts
+between them,
+so no work is ever lost.
+
+We'll finish by pulling these changes into other copy of the repo,
+so both copies are up to date:
+
+```
+$ cd ../git-papers			# Switch to 'git-papers' directory
+$ git pull origin master	# Merge remote branch into local
+```
+{: .language-bash}

--- a/tu-git-dupre/06-pull-requests.md
+++ b/tu-git-dupre/06-pull-requests.md
@@ -1,0 +1,92 @@
+---
+title: "Pull Requests"
+teaching: 5
+exercises: 10
+questions:
+- "How can I contribute to a repository to which I don't have write access?"
+objectives:
+- "Understand what it means to fork a repository"
+- "Be able to fork a repository on GitHub"
+- "Understand how to submit a pull request"
+keypoints:
+- "A `fork` is a `git clone` into your (GitHub) account"
+- "A `pull request` asks the owner of a repository to incorporate your changes"
+---
+
+Pull Requests are a great solution for contributing to repositories to which
+you don't have write access.
+Adding other people as *collaborators* to a remote repository is a good idea,
+but sometimes you may not have a specific group of potential collaborators in mind.
+
+This is especially true of open source projects,
+in which the community of potential contributors can be very big.
+Keeping the source code safe--but at the same allowing new people to make contributions--is one of the keys to success in open source.
+
+Leveraging the power of Git,
+GitHub provides a functionality called *Pull Requests*.
+Essentially, it's "requesting the owner of the repository to pull in
+your contributions".
+As the owner of a repository, you may or may not accept a pull request.
+But as a contributor, pull requests provide a path to engage with the community.
+
+## The process
+
+- Find a repository on GitHub that belongs to someone else (e.g., https://github.com/emdupre/more-papers)
+- **Fork** it on GitHub's servers into your GitHub account
+- Then `git clone` it to your PC/laptop
+- Make changes, and push them to your repository on GitHub
+- Request that the owner of the repository you *forked* pulls in your changes
+
+![Conceptual illustration of a pull request - image adapted from [here](http://acrl.ala.org/techconnect/post/coding-collaboration-on-github)](../fig/github-diagram.png)
+
+## Advice for submitting Pull Requests
+
+- Keep your Pull Request small and focused (makes it easier to process!)
+	- Submit one PR per issue
+	- Create a separate branch for each issue you work on
+	  (you can submit a PR from any branch)
+- Take advantage of available resources!
+	- If the repository has contributing guidelines, read them!
+	- Some repositories pre-populate the body of the PR or issue message
+	  with a template.
+		- Follow the instructions (e.g. provide the information requested)
+- Consider creating a new issue first to discuss your ideas before submitting a PR.
+  Some repositories ask for this in their contributing guidelines,
+  but this can be a good approach even if it isn't required,
+  so that you know whether the owner agrees with your suggestion.
+  They might also bring up ideas and/or challenges you haven't considered.
+
+## After submitting your pull request
+
+Your PR may get merged just as it is.
+It's very normal, too, for there to be some discussion (on GitHub)
+and a request for further edits to be made.
+Given that your pull request haven't been merged get,
+you can make changes by adding further commits to your branch and pushing them.
+In either case, your PR will update automatically once you have pushed your commits.
+
+> ## Exercise
+> Let's look at the workflow and try to repeat it:
+>
+> 1. **Fork** [this
+> repository](https://github.com/emdupre/more-papers.git)
+> by  clicking on the `Fork` button at the top of the page.
+>
+> 2. Clone the repository from **YOUR** GitHub account. When you run `git remote -v`
+> you should get something like this:
+>
+> 	```{.output}
+>	origin	https://github.com/YOUR_USERNAME/more-papers.git(fetch)
+> 	origin	https://github.com/YOUR_USERNAME/more-papers.git(push)
+> 	```
+>
+> 3. `cd` into the directory you just cloned. Make changes you want to contribute.
+> Commit and push them back to your repository.
+> You won't be able to push back to the repository you forked from
+> because you are not added as a contributor!
+> 4. Go to your GitHub account and in the forked repository find a green button
+> for creating Pull Requests. Click it and follow the instructions.
+> 5. The owner of the original repository gets a notification that someone
+> created a pull request - the request can be reviewed, commented and merged in
+> (or not) via GitHub.
+{: .challenge}

--- a/tu-git-dupre/README.md
+++ b/tu-git-dupre/README.md
@@ -1,0 +1,18 @@
+# git-course
+
+## Version control with Git
+
+**Author:** Elizabeth DuPre
+
+This is an introduction to using version control with Git and GitHub,
+intended to be presented at NeuroHackademy 2020.
+
+You can find the rendered version of this lesson here:
+
+https://emdupre.github.io/git-course
+
+No prior experience with version control is assumed.
+The material is based on the Software Carpentry lesson and the work of Aleksandra Pawlik, but has been heavily modified.
+
+If you have any questions,
+please open an issue or contact Elizabeth directly!

--- a/tu-git-dupre/index.md
+++ b/tu-git-dupre/index.md
@@ -1,0 +1,41 @@
+---
+layout: lesson
+root: .
+---
+**This course is based on materials by [Software Carpentry](http://www.software-carpentry.org)**
+
+> ## Prerequisites
+> In this lesson we use Git from the Unix Shell.
+> Some previous experience with the shell is expected,
+> *but is not mandatory*.
+>
+> We expect that participants will execute this lesson on the
+> NeuroHackademy JupyterHub (hub.neurohackademy.org).
+>
+> If instead you'd like to execute it locally, you can use your
+> local unix shell (either natively on Mac & Linux or under WSL on Windows).
+>
+> Alternatively, this course can be followed on Windows using
+> Git Bash.
+> All of the commands shown will work on Windows using Git Bash,
+> with the exception of the `vim` command.
+> vim is a common text editor on Linux:
+> Windows users should use the `notepad` command instead, and set
+> notepad as the core editor when configuring Git.
+>
+> You will need a GitHub account for this session.
+> Please [sign up for an account](https://github.com/)
+> if you do not already have one.
+{: .prereq}
+
+## Resources
+
+You can check out the slides for this workshop [here](https://slides.com/emdupre/git-course).
+
+Note that there are lots of other great resources out there !
+Here are a few of our favorites:
+
+* [Introduction to GitHub: A visual guide](https://zenodo.org/record/3369466)
+* [Mozilla open leadership GitHub training](https://mozilla.github.io/open-leadership-training-series/articles/get-your-project-online/introducing-github-for-collaborative-work-and-version-control/)
+* [Happy Git and GitHub for the useR](https://happygitwithr.com/)
+* [try.github.io](https://try.github.io/)


### PR DESCRIPTION
I'm intending for students to follow along with the [rendered version](https://emdupre.github.io/git-course), but this way they also have a local copy of the supporting markdown files !